### PR TITLE
Accept a comma-separated list of ports to forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ OPTIONS
   -r, --remote=remote        git remote of app to use
 
 DESCRIPTION
+  Provide a port or comma-separated list of ports to forward.
+
+  For example, "4000,9000:9001" will forward port 4000 to port 4000 and
+  port 9000 to port 9001.
+
   Example:
 
        $ heroku ps:forward 8080 --app murmuring-headland-14719


### PR DESCRIPTION
Hi! 👋 Former Herokai, now Hubber here 😄 

Instead of accepting only a single port to forward, this allows `heroku ps:forward` to forward multiple ports from a comma-separated list.

There is documentation in the dev center that says to use `heroku ps:socks` in order to forward multiple ports, but this only works with socks-aware software.

For example, it is not possible to use the amazing GUI Observer module that OTP provides for Erlang/Elixir apps unless `heroku ps:forward` can forward _both_ to the epmd port on the dyno and to the port the dyno is listening on for distributed node connections. epmd is not socks-aware.

Making this change would allow for [the caveat in the Phoenix documentation](https://hexdocs.pm/phoenix/heroku.html#limitations) that says that Observer isn't supported to be removed!

_Note: I have nooooo idea if this is the right format for accepting multiple port arguments as per current Heroku CLI design guidelines. I'd love some feedback on making this more idiomatic, if there's interest in supporting this feature!_

_Another note: I'm not really familiar with socks...I just hacked around and this appeared to work. So very likely there's a better way of implementing this, I have no idea 😄_