### PR TITLE
feat: add command name to initFeature function call for ps:exec

### DIFF
--- a/commands/ssh.js
+++ b/commands/ssh.js
@@ -24,7 +24,7 @@ module.exports = function (topic, command) {
 }
 
 function * run (context, heroku) {
-  yield exec.initFeature(context, heroku, function *(configVars) {
+  yield exec.initFeature(context, heroku, 'exec', function *(configVars) {
     if (context.flags.status) {
       yield exec.checkStatus(context, heroku, configVars)
     } else {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@heroku-cli/heroku-exec-util": "0.8.2",
+    "@heroku-cli/heroku-exec-util": "0.9.0",
     "@heroku/heroku-cli-util": "^8.0.13"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
     open "^6.2.0"
     uuid "^8.3.0"
 
-"@heroku-cli/heroku-exec-util@0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@heroku-cli/heroku-exec-util/-/heroku-exec-util-0.8.2.tgz#356a0f516db5d27c95a705b1f76f739b006a5028"
-  integrity sha512-KNYXKt4msDHJEs0/yLzfH7chTURlgJuGGIeVE2BrAIVR/0j6G2ItDCu6TBtfGJfJu3tc8U35YLIKxsRNQBlrFQ==
+"@heroku-cli/heroku-exec-util@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/heroku-exec-util/-/heroku-exec-util-0.9.0.tgz#2ca6ed23f79c2377d8856cad2a7b7f4448f8f89c"
+  integrity sha512-Yc+BQ+A1ATg0srZUbEXI9KDkr8IY0beSmnZLIeQOpSSVDTEpuOwPavXo/OD+xLlvDLf3A1SXlTvVzqeDjJ/XKA==
   dependencies:
     "@heroku/heroku-cli-util" "^8.0.13"
     "@heroku/socksv5" "^0.0.9"


### PR DESCRIPTION
## Description
This PR is part of the work to disable commands from this plugin for fir apps. The rest of the work is contained in heroku/heroku-exec-util#42. We needed to display a different error message for the `ps:exec` command than we do for the other commands in this plugin and the easiest way to accomplish this was to send the command name through to the `initFeature` command, from which the error messages are returned for fir apps. That is all this PR does.

## Testing
Even though most of the work happens in the heroku/heroku-exec-util#42, I'm adding the testing instructions here. There is a bit of setup for testing these changes, I'll detail that below. This is especially important because there wasn't a good/easy way to add tests for this logic.

### Testing setup
1. If you haven't already, clone this repo and the heroku/heroku-exec-util repo locally
2. Check out the branch for this commit and run `yarn`
3. Check out the branch for heroku/heroku-exec-util and run `yarn`
4. If you haven't already make sure you have a fir app with a dyno and a cedar app with a dyno created and ready for testing
5. From the heroku-exec-util repo, run `yarn link`
6. Copy the command that prints and run it in heroku-ps-exec
7. From heroku-ps-exec, run `heroku plugins:link` to link your local version of the plugin to your heroku CLI installation

### Testing steps
Using your fir app:
1. Run `heroku ps:exec 'node -i' -a YOUR_FIR_APP`
    - Validate that the command exits and you see an error message that says "This command is unavailable for this app. Use `heroku run:inside` instead. See https://devcenter.heroku.com/articles/run-tasks-in-an-existing-dyno."
2. Run `heroku ps:forward 8080 -a YOUR_FIR_APP`
    - Validate that the command exits and you see an error message that says "This command is unavailable for this app.  See https://devcenter.heroku.com/articles/generations."
3. Run `heroku ps:socks -a k80-test-scripts-fir -a YOUR_FIR_APP`
    - Validate that the command exits and you see an error message that says "This command is unavailable for this app.  See https://devcenter.heroku.com/articles/generations."
4. Run `heroku ps:copy FILENAME -a YOUR_FIR_APP` (choose any file, it doesn't matter)
    - Validate that the command exits and you see an error message that says "This command is unavailable for this app.  See https://devcenter.heroku.com/articles/generations."

Using your cedar app:
1. Run all the commands above and validate that none of the above error messages appear. It doesn't matter if the commands error out in other ways, that's fine. We just want to make sure the user doesn't see any of the error messages we've added for fir.

[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000201utZYAQ/view)