### PR TITLE
Fixing bug with other 'ps' commands besides 'ps:exec'

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 assert_equal() {
   local expected="${1}"
@@ -110,14 +110,37 @@ git init
 web="ruby -rwebrick -e\"s=WEBrick::HTTPServer.new(:BindAddress => '0.0.0.0', :Port => \$PORT, :DocumentRoot => Dir.pwd); s.mount_proc('/'){|q,r| r.body='Hello'}; s.start\""
 echo "web: ${web}" > Procfile
 echo "worker: echo 'success' > ${file_to_copy}; ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => 3000, :DocumentRoot => Dir.pwd).start'" >> Procfile
+cat <<-EOF > Gemfile
+source "https://rubygems.org"
+ruby "3.2.6"
+gem "webrick"
+EOF
+cat <<-EOF > Gemfile.lock
+GEM
+  remote: https://rubygems.org/
+  specs:
+    webrick (1.9.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  webrick
+
+RUBY VERSION
+   ruby 3.2.6p234
+
+BUNDLED WITH
+   2.4.19
+EOF
 
 echo "Creating Heroku app..."
 heroku create ${app} $(if [ -n "$HEROKU_SPACE" ]; then echo "--space $HEROKU_SPACE"; else echo "--region ${HEROKU_REGION:-us}"; fi)
 
 trap "{ cleanup ${app}; }" EXIT
 
-heroku buildpacks:set https://github.com/ryandotsmith/null-buildpack
-git add Procfile
+git add Procfile Gemfile Gemfile.lock
 git commit -m "first"
 
 if [ "${1-}" == "staging" ] || [ "${HEROKU_EXEC_TEST_ENV-}" == "staging" ]; then
@@ -147,7 +170,7 @@ assert_contains "Could not connect to dyno!" "$output"
 echo "=== test 2: success"
 
 echo "Deploying..."
-git push heroku master
+git push heroku main
 
 wait_for_dyno "web"
 

--- a/commands/copy.js
+++ b/commands/copy.js
@@ -32,7 +32,7 @@ function * run(context, heroku) {
   if (fs.existsSync(dest)) {
     cli.error(`The local file ${cli.color.white.bold(dest)} already exists!`)
   } else {
-    yield exec.initFeature(context, heroku, function *(configVars) {
+    yield exec.initFeature(context, heroku, 'copy', function *(configVars) {
       yield exec.updateClientKey(context, heroku, configVars, function(privateKey, dyno, response) {
         var message = `Connecting to ${cli.color.cyan.bold(dyno)} on ${cli.color.app(context.app)}`
         cli.action(message, {success: false}, co(function* () {

--- a/commands/port.js
+++ b/commands/port.js
@@ -30,7 +30,7 @@ module.exports = function(topic, command) {
 };
 
 function * run(context, heroku) {
-  yield exec.initFeature(context, heroku, function *(configVars) {
+  yield exec.initFeature(context, heroku, 'forward', function *(configVars) {
     const portMappings = context.args.port.split(',').map(function(portMapping) {
       const ports = portMapping.split(':')
 
@@ -50,7 +50,7 @@ function * run(context, heroku) {
           socks.connect({
             host: '0.0.0.0',
             port: remotePort,
-            proxyHost: '127.0.0.1',
+            proxyHost: 'localhost',
             proxyPort: socksPort,
             auths: [ socks.auth.None() ]
           }, function(socket) {

--- a/commands/socks.js
+++ b/commands/socks.js
@@ -24,7 +24,7 @@ module.exports = function(topic, command) {
 };
 
 function * run(context, heroku) {
-  yield exec.initFeature(context, heroku, function *(configVars) {
+  yield exec.initFeature(context, heroku, 'socks', function *(configVars) {
     yield exec.createSocksProxy(context, heroku, configVars)
   });
   return new Promise(resolve => {})


### PR DESCRIPTION
## Description

When changes were introduced on `heroku-exec-util` to handle Fir apps, the signature for its `initFeature` function was changed, but only `ps:exec` command was modified on this project to use the new signature, breaking all other implemented commands: `ps:forward`, `ps:copy` and `ps:socks` that also used that function to initialize the configuration.

Here we fix those issues adding the missing parameter to the function call on all commands except for `ps:status` that seems to be dead code and should be removed on a follow up PR. We also introduce a change when connecting the local forwarded port to the SOCKSv5 server replacing '127.0.0.1' for 'localhost' as the `proxyHost` in `ps:forward` to fix a connection issue when the host uses IPv6 DNS resolution.

Finally, there's an integration test available at `/bin/test` that was completely broken after Ruby libraries were removed from `heroku-22` and newer stacks. Here we provide a fix for that test to allow at least testing on a local development box.

## Test

Run `yarn test`

## Issues

Fixes https://github.com/heroku/cli/issues/3153.

## SOC2

[GUS Work Item](https://gus.lightning.force.com/a07EE000027HO0TYAW) (Heroku internal)
